### PR TITLE
Update rainbow-overrides.json

### DIFF
--- a/rainbow-overrides.json
+++ b/rainbow-overrides.json
@@ -554,9 +554,10 @@
     "shadowColor": "#D09AAC"
   },
   "0x6d0f5149c502faf215c89ab306ec3e50b15e2892": {
-    "color": "#062A3D"
+    "color": "#062A3D",
     "isCurated": true,
     "name": "Portion Token",
-    "shadowColor": "#DAB679"
+    "shadowColor": "#DAB679",
+    "symbol": "PRT"
   }
 }

--- a/rainbow-overrides.json
+++ b/rainbow-overrides.json
@@ -552,5 +552,11 @@
     "isCurated": true,
     "name": "YAM",
     "shadowColor": "#D09AAC"
+  },
+  "0x6d0f5149c502faf215c89ab306ec3e50b15e2892": {
+    "color": "#062A3D"
+    "isCurated": true,
+    "name": "Portion Token",
+    "shadowColor": "#DAB679"
   }
 }


### PR DESCRIPTION
add override for Portion.io token. the goal is to remove the "scam token" label on this token and have the correct colors show up.