### PR TITLE
Set up publishing schedule cron

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,11 @@
 name: Publish
 
 on:
-  workflow_dispatch:
+  branches:
+    - main  # any change to main branch
+  workflow_dispatch:  # any time you press the job button
+  schedule:
+    - cron: "0 0,12 * * *"  # every day at 00:00 and 12:00
 
 env:
   node-version: lts/*


### PR DESCRIPTION
This sets up automated publishing to cloud front/s3.

- Whenever `main` changes
- Whenever you press the publish button
- Twice a day