### PR TITLE
add cabindao token override

### DIFF
--- a/rainbow-overrides.json
+++ b/rainbow-overrides.json
@@ -1,4 +1,9 @@
 {
+  "0x1934E252f840aA98dfCe2b6205B3E45c41AeF830": {
+    "color": "#08FC4C",
+    "name": "₡ABIN",
+    "symbol": "₡ABIN"
+  },
   "0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd": {
     "color": "#29292E",
     "isCurated": true,


### PR DESCRIPTION
Fixes RNBW-2428

https://user-images.githubusercontent.com/15272675/152593026-a4e73a92-bb28-4b72-a3c8-25d6c051f88f.mp4

I created this demo by modifying `rainbow-token-list.json` directly. I'm wondering if adding it to `rainbow-overrides.json` will override the token icon as well. If so, I'll need to re-add it here https://github.com/rainbow-me/assets. 
