### PR TITLE
Use cloudflare DNS instead of local resolver

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,12 @@ jobs:
           node-version: ${{ env.node-version }}
           cache: yarn
 
+      - name: Use Cloudflare DNS
+        run: |
+          sudo rm /etc/resolv.conf
+          echo "nameserver 1.1.1.1" > resolv.conf
+          sudo cp resolv.conf /etc/resolv.conf
       - run: yarn
-      - run: yarn lint
-      - run: yarn test --ci --coverage --maxWorkers=2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
 
+      - name: Use Cloudflare DNS
+        run: |
+          sudo rm /etc/resolv.conf
+          echo "nameserver 1.1.1.1" > resolv.conf
+          sudo cp resolv.conf /etc/resolv.conf
       - run: yarn
       - run: yarn lint
       - run: yarn test --ci --coverage --maxWorkers=2


### PR DESCRIPTION
After testing elsewhere, `eth.link` resolutions on GitHub CI seem to fail periodically through the local resolver 

This PR forces DNS resolution through 1.1.1.1 instead


```
; <<>> DiG 9.16.1-Ubuntu <<>> tokenlist.aave.eth.link
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 5236
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;tokenlist.aave.eth.link.	IN	A
;; Query time: 264 msec
;; SERVER: 127.0.0.53#53(127.0.0.53)
;; WHEN: Fri Jun 10 22:54:16 UTC 2022
;; MSG SIZE  rcvd: 52


; <<>> DiG 9.16.1-Ubuntu <<>> tokenlist.aave.eth.link @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 47611
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; OPT=15: 00 0a 66 6f 72 20 44 4e 53 4b 45 59 20 6c 69 6e 6b 2e 2c 20 69 64 20 3d 20 33 33 36 33 31 ("..for DNSKEY link., id = 33631")
;; QUESTION SECTION:
;tokenlist.aave.eth.link.	IN	A
;; ANSWER SECTION:
tokenlist.aave.eth.link. 86400	IN	CNAME	resolver.cloudflare-eth.com.
resolver.cloudflare-eth.com. 300 IN	A	104.18.165.219
resolver.cloudflare-eth.com. 300 IN	A	104.18.166.219
;; Query time: 92 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Fri Jun 10 22:54:16 UTC 2022
;; MSG SIZE  rcvd: 159


; <<>> DiG 9.16.1-Ubuntu <<>> tokenlist.dharma.eth.link
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 41389
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;tokenlist.dharma.eth.link.	IN	A
;; Query time: 276 msec
;; SERVER: 127.0.0.53#53(127.0.0.53)
;; WHEN: Fri Jun 10 22:54:17 UTC 2022
;; MSG SIZE  rcvd: 54


; <<>> DiG 9.16.1-Ubuntu <<>> tokenlist.dharma.eth.link @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 51651
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; OPT=15: 00 0a 66 6f 72 20 44 4e 53 4b 45 59 20 6c 69 6e 6b 2e 2c 20 69 64 20 3d 20 33 33 36 33 31 ("..for DNSKEY link., id = 33631")
;; QUESTION SECTION:
;tokenlist.dharma.eth.link.	IN	A
;; ANSWER SECTION:
tokenlist.dharma.eth.link. 86400 IN	CNAME	resolver.cloudflare-eth.com.
resolver.cloudflare-eth.com. 300 IN	A	104.18.165.219
resolver.cloudflare-eth.com. 300 IN	A	104.18.166.219
;; Query time: 112 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Fri Jun 10 22:54:17 UTC 2022
;; MSG SIZE  rcvd: 161


; <<>> DiG 9.16.1-Ubuntu <<>> synths.snx.eth.link
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 56689
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;synths.snx.eth.link.		IN	A
;; Query time: 264 msec
;; SERVER: 127.0.0.53#53(127.0.0.53)
;; WHEN: Fri Jun 10 22:54:17 UTC 2022
;; MSG SIZE  rcvd: 48


; <<>> DiG 9.16.1-Ubuntu <<>> synths.snx.eth.link @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50573
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; OPT=15: 00 0a 66 6f 72 20 44 4e 53 4b 45 59 20 6c 69 6e 6b 2e 2c 20 69 64 20 3d 20 33 33 36 33 31 ("..for DNSKEY link., id = 33631")
;; QUESTION SECTION:
;synths.snx.eth.link.		IN	A
;; ANSWER SECTION:
synths.snx.eth.link.	86400	IN	CNAME	resolver.cloudflare-eth.com.
resolver.cloudflare-eth.com. 300 IN	A	104.18.165.219
resolver.cloudflare-eth.com. 300 IN	A	104.18.166.219
;; Query time: 112 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Fri Jun 10 22:54:17 UTC 2022
;; MSG SIZE  rcvd: 155


; <<>> DiG 9.16.1-Ubuntu <<>> wrapped.tokensoft.eth.link
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 20277
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;wrapped.tokensoft.eth.link.	IN	A
;; ANSWER SECTION:
wrapped.tokensoft.eth.link. 1800 IN	CNAME	resolver.cloudflare-eth.com.
resolver.cloudflare-eth.com. 299 IN	A	104.18.166.219
resolver.cloudflare-eth.com. 299 IN	A	104.18.165.219
;; Query time: 236 msec
;; SERVER: 127.0.0.53#53(127.0.0.53)
;; WHEN: Fri Jun 10 22:54:18 UTC 2022
;; MSG SIZE  rcvd: 128


; <<>> DiG 9.16.1-Ubuntu <<>> wrapped.tokensoft.eth.link @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 3736
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; OPT=15: 00 0a 66 6f 72 20 44 4e 53 4b 45 59 20 6c 69 6e 6b 2e 2c 20 69 64 20 3d 20 33 33 36 33 31 ("..for DNSKEY link., id = 33631")
;; QUESTION SECTION:
;wrapped.tokensoft.eth.link.	IN	A
;; ANSWER SECTION:
wrapped.tokensoft.eth.link. 86400 IN	CNAME	resolver.cloudflare-eth.com.
resolver.cloudflare-eth.com. 300 IN	A	104.18.165.219
resolver.cloudflare-eth.com. 300 IN	A	104.18.166.219
;; Query time: 60 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Fri Jun 10 22:54:18 UTC 2022
;; MSG SIZE  rcvd: 162
```